### PR TITLE
Fixed compile warnings.

### DIFF
--- a/src/vision.cpp
+++ b/src/vision.cpp
@@ -269,10 +269,24 @@ bool Vision::start()
           RCLCPP_ERROR(node_->get_logger(), "[%s]: Failed to start stream", camera_name_.c_str());
           return false;
 
+        case GST_STATE_CHANGE_NO_PREROLL:
+          RCLCPP_INFO(node_->get_logger(), "[%s]: Stream started (no preroll)", camera_name_.c_str());
+          break;
+
         case GST_STATE_CHANGE_ASYNC:
           RCLCPP_ERROR(node_->get_logger(), "[%s]: Failed to start stream (timeout)", camera_name_.c_str());
           return false;
+
+        case GST_STATE_CHANGE_SUCCESS:
+          RCLCPP_INFO(node_->get_logger(), "[%s]: Stream started (async)", camera_name_.c_str());
+          break;
+
+        default:
+          RCLCPP_ERROR(node_->get_logger(), "[%s]: Unknown state change result", camera_name_.c_str());
+          return false;
       }
+
+      break;
     }
 
     case GST_STATE_CHANGE_SUCCESS:
@@ -380,7 +394,7 @@ bool Vision::publish()
   // Update header information
   auto cur_cinfo = camera_info_manager_->getCameraInfo();
 
-  if (cur_cinfo.height != image_height_ || cur_cinfo.width != image_width_)
+  if (static_cast<int>(cur_cinfo.height) != image_height_ || static_cast<int>(cur_cinfo.width) != image_width_)
   {
     RCLCPP_WARN_ONCE(node_->get_logger(),
                      "[%s]: Calibration file sensor resolution (%dx%d pixels) doesn't match stream resolution (%dx%d "


### PR DESCRIPTION
# Issue

https://github.com/PickNikRobotics/moveit_pro/issues/13061

## Description

I fixed the following warnings

```bash
--- stderr: kinova_vision                                                                             
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp: In member function ‘bool ros_kortex_vision::Vision::start()’:
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp:266:14: warning: enumeration value ‘GST_STATE_CHANGE_SUCCESS’ not handled in switch [-Wswitch]
  266 |       switch (ret)
      |              ^
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp:266:14: warning: enumeration value ‘GST_STATE_CHANGE_NO_PREROLL’ not handled in switch [-Wswitch]
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp: In member function ‘bool ros_kortex_vision::Vision::publish()’:
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp:383:24: warning: comparison of integer expressions of different signedness: ‘sensor_msgs::msg::CameraInfo_<std::allocator<void> >::_height_type’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
  383 |   if (cur_cinfo.height != image_height_ || cur_cinfo.width != image_width_)
      |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp:383:60: warning: comparison of integer expressions of different signedness: ‘sensor_msgs::msg::CameraInfo_<std::allocator<void> >::_width_type’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
  383 |   if (cur_cinfo.height != image_height_ || cur_cinfo.width != image_width_)
      |                                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp: In member function ‘bool ros_kortex_vision::Vision::start()’:
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp:276:5: warning: this statement may fall through [-Wimplicit-fallthrough=]
  276 |     }
      |     ^
/home/parallels/user_ws/src/external_dependencies/ros2_kortex_vision/src/vision.cpp:278:5: note: here
  278 |     case GST_STATE_CHANGE_SUCCESS:
      |     ^~~~
---
```